### PR TITLE
add DIFE handling

### DIFF
--- a/src/MBUSPayload.cpp
+++ b/src/MBUSPayload.cpp
@@ -209,7 +209,6 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
     bool dife = ((dif & 0x80) == 0x80); //check if the first bit of DIF marked as "DIFE is following" 
     while(dife) {
       index++;
-      client.publish(String("busino/debug/decodeDIFE" + String(index-1)), String(buffer[index-1]).c_str());
       dife = false;
       dife = ((buffer[index-1] & 0x80) == 0x80); //check if after the DIFE another DIFE is following 
       } 

--- a/src/MBUSPayload.cpp
+++ b/src/MBUSPayload.cpp
@@ -203,6 +203,7 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
     // Decode DIF
     uint8_t dif = buffer[index++];
     uint8_t difLeast4bit = (dif & 0x0F);
+	uint8_t difFunctionField = ((dif & 0x30) >> 4);
     uint8_t len = 0;
     uint8_t dataCodingType = 0;
     /*
@@ -293,7 +294,23 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
             break;
 
     }
-    
+	char stringFunctionField[5];
+	switch(difFunctionField){
+		case 0:
+			strcpy(stringFunctionField, ""); //current
+			break;
+		case 1:
+			strcpy(stringFunctionField, "_max");
+			break;
+		case 2:
+			strcpy(stringFunctionField, "_min");
+			break;
+		case 3:
+			strcpy(stringFunctionField, "_err");
+			break;
+	}
+			
+			
     // handle DIFE to prevent stumble if a DIFE is used
     bool dife = ((dif & 0x80) == 0x80); //check if the first bit of DIF marked as "DIFE is following" 
     while(dife) {
@@ -477,8 +494,8 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
     data["value_raw"] = value;
     data["value_scaled"] = scaled;
     data["units"] = String(getCodeUnits(vif_defs[def].code));
-    data["name"] = String(getCodeName(vif_defs[def].code));
-	data["date"] = String(datestring2);  
+    data["name"] = String(getCodeName(vif_defs[def].code)+String(stringFunctionField));
+	// data["date"] = String(datestring2);  formatted dates, optional
   
   }
 

--- a/src/MBUSPayload.cpp
+++ b/src/MBUSPayload.cpp
@@ -204,6 +204,17 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
     uint8_t dif = buffer[index++];
     bool bcd = ((dif & 0x08) == 0x08);
     uint8_t len = (dif & 0x07);
+    
+    // handle DIFE to prevent stumble if a DIFE is used
+    bool dife = ((dif & 0x80) == 0x80); //check if the first bit of DIF marked as "DIFE is following" 
+    while(dife) {
+      index++;
+      client.publish(String("busino/debug/decodeDIFE" + String(index-1)), String(buffer[index-1]).c_str());
+      dife = false;
+      dife = ((buffer[index-1] & 0x80) == 0x80); //check if after the DIFE another DIFE is following 
+      } 
+    //  End of DIFE handling
+    
     if ((len < 1) || (4 < len)) {
       _error = MBUS_ERROR::UNSUPPORTED_CODING;
       return 0;

--- a/src/MBUSPayload.cpp
+++ b/src/MBUSPayload.cpp
@@ -436,15 +436,20 @@ uint8_t MBUSPayload::decode(uint8_t *buffer, uint8_t size, JsonArray& root) {
             	date[i] =  buffer[index + i];
 			}            
 			
-/*            if ((date[1] & 0x0F) > 12) {    // Time valid ?
+           if ((date[1] & 0x0F) > 12) {    // Time valid ?
                 //out_len = snprintf(output, output_size, "invalid");
                 break;
-            }*/
+            }
             out_len = snprintf(datestring, 10, "%02d%02d%02d",
                 ((date[0] & 0xE0) >> 5) | ((date[1] & 0xF0) >> 1), // year
                 date[1] & 0x0F, // mon
                 date[0] & 0x1F  // mday
             );
+            out_len = snprintf(datestring2, 10, "%02d-%02d-%02d",
+                ((date[0] & 0xE0) >> 5) | ((date[1] & 0xF0) >> 1), // year
+                date[1] & 0x0F, // mon
+                date[0] & 0x1F  // mday
+            );			
 			value = atof( datestring);
             break;
 		default:

--- a/src/MBUSPayload.h
+++ b/src/MBUSPayload.h
@@ -26,7 +26,7 @@ along with the MBUSPayload library.  If not, see <http://www.gnu.org/licenses/>.
 #include <Arduino.h>
 #include <ArduinoJson.h>
 
-#define MBUS_DEFAULT_BUFFER_SIZE          32
+#define MBUS_DEFAULT_BUFFER_SIZE          510
 #define ARDUINO_FLOAT_MIN                 1e-6  // Assume 0 if less than this
 #define ARDUINO_FLOAT_DECIMALS            6     // 6 decimals is just below the limit for Arduino float maths
 
@@ -57,8 +57,8 @@ enum MBUS_CODE {
   TEMPERATURE_DIFF_K, 
   EXTERNAL_TEMPERATURE_C, 
   PRESSURE_BAR, 
-  //TIME_POINT_DATE,
-  //TIME_POINT_DATETIME,
+  TIME_POINT_DATE,
+  TIME_POINT_DATETIME,
   //HCA,
   AVG_DURATION_S,
   AVG_DURATION_MIN,
@@ -81,7 +81,7 @@ enum MBUS_CODE {
   MODEL_VERSION,
   HARDWARE_VERSION,
   FIRMWARE_VERSION,
-  //SOFTWARE_VERSION,
+  SOFTWARE_VERSION,
   //CUSTOMER_LOCATION,
   CUSTOMER,
   //ACCESS_CODE_USER,
@@ -114,6 +114,9 @@ enum MBUS_CODE {
   TEMPERATURE_LIMIT_F,
   TEMPERATURE_LIMIT_C,
   MAX_POWER_W,
+
+  // VIFE 0xFC
+  UNSUPPORTED_X,
   
 };
 
@@ -141,7 +144,7 @@ enum MBUS_ERROR {
 
 // VIF codes
 
-#define MBUS_VIF_DEF_NUM                  73
+#define MBUS_VIF_DEF_NUM                  77
 
 typedef struct {
   uint8_t code;
@@ -176,8 +179,8 @@ static const vif_def_type vif_defs[MBUS_VIF_DEF_NUM] = {
   { MBUS_CODE::TEMPERATURE_DIFF_K      , 0x60     , 4,  -3},
   { MBUS_CODE::EXTERNAL_TEMPERATURE_C  , 0x64     , 4,  -3},
   { MBUS_CODE::PRESSURE_BAR            , 0x68     , 4,  -3},
-  //{ MBUS_CODE::TIME_POINT_DATE         , 0x6C     , 1,   0},
-  //{ MBUS_CODE::TIME_POINT_DATETIME     , 0x6D     , 1,   0},
+  { MBUS_CODE::TIME_POINT_DATE         , 0x6C     , 1,   0},
+  { MBUS_CODE::TIME_POINT_DATETIME     , 0x6D     , 1,   0},
   //{ MBUS_CODE::HCA                     , 0x6E     , 1,   0},
   { MBUS_CODE::AVG_DURATION_S          , 0x70     , 1,   0},
   { MBUS_CODE::AVG_DURATION_MIN        , 0x71     , 1,   0},
@@ -203,7 +206,7 @@ static const vif_def_type vif_defs[MBUS_VIF_DEF_NUM] = {
   { MBUS_CODE::MODEL_VERSION           , 0xFD0C   ,  1,   0},
   { MBUS_CODE::HARDWARE_VERSION        , 0xFD0D   ,  1,   0},
   { MBUS_CODE::FIRMWARE_VERSION        , 0xFD0E   ,  1,   0},
-  //{ MBUS_CODE::SOFTWARE_VERSION        , 0xFD0F   ,  1,   0},
+  { MBUS_CODE::SOFTWARE_VERSION        , 0xFD0F   ,  1,   0},  //neu
   //{ MBUS_CODE::CUSTOMER_LOCATION       , 0xFD10   ,  1,   0},
   { MBUS_CODE::CUSTOMER                , 0xFD11   ,  1,   0},
   //{ MBUS_CODE::ACCESS_CODE_USER        , 0xFD12   ,  1,   0},
@@ -244,6 +247,9 @@ static const vif_def_type vif_defs[MBUS_VIF_DEF_NUM] = {
   { MBUS_CODE::TEMPERATURE_LIMIT_C     , 0xFB74   , 4,  -3},
   { MBUS_CODE::MAX_POWER_W             , 0xFB78   , 8,  -3},
 
+  // VIFE 0xFC
+  { MBUS_CODE::UNSUPPORTED_X           , 0xFC00   , 254,  0}
+
 };
 
 class MBUSPayload {
@@ -278,5 +284,4 @@ protected:
   uint8_t _error = NO_ERROR;
 
 };
-
 #endif


### PR DESCRIPTION
The code snipped prevent the libary to come out of step if a DIFE is used. DIFE fields are NOT analyzed, but now you can read out the whole telegram without a failure and get some usefull data. Tested with a Engelmann Sensostar U, which use some DIFE.

```c++
// handle DIFE to prevent stumble if a DIFE is used
bool dife = ((dif & 0x80) == 0x80); //check if the first bit of DIF marked as "DIFE is following" 
while(dife) {
   index++;
   dife = false;
   dife = ((buffer[index-1] & 0x80) == 0x80); //check if after the DIFE another DIFE is following 
      } 
    //  End of DIFE handling
``` 

One another question:
Why the time points are commented out?


```c++
  //{ MBUS_CODE::TIME_POINT_DATE         , 0x6C     , 1,   0},
  //{ MBUS_CODE::TIME_POINT_DATETIME     , 0x6D     , 1,   0},
``` 